### PR TITLE
Pin `integrations/key-server` python dependencies to the latest versions

### DIFF
--- a/integrations/key-server/requirements.txt
+++ b/integrations/key-server/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.104.0
-uvicorn==0.23.2
-python-multipart==0.0.6
-python-gnupg==0.5.1
+fastapi==0.115.12
+uvicorn==0.34.2
+python-multipart==0.0.20
+python-gnupg==0.5.4


### PR DESCRIPTION
Pin `integrations/key-server` **python** dependencies to the latest versions.
This also solves the following Dependabot alerts:
- [x] https://github.com/drclau/gwmilter/security/dependabot/2
- [x] https://github.com/drclau/gwmilter/security/dependabot/1