### PR TITLE
Introduce SignalManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ find_library(EPDFCRYPT_LIBRARY NAMES epdfcrypt HINTS ${EPDFCRYPT_PATH}/lib)
 # Define the executable and its source files
 add_executable(gwmilter
         src/main.cpp
+        src/signal_manager.hpp
+        src/signal_manager.cpp
         src/cfg/cfg.hpp
         src/cfg/cfg.cpp
         src/handlers/body_handler.hpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "cfg/cfg.hpp"
 #include "logger/logger.hpp"
 #include "milter/milter.hpp"
+#include "signal_manager.hpp"
 #include "utils/string.hpp"
 #include <boost/exception/diagnostic_information.hpp>
 #include <cerrno>
@@ -112,12 +113,14 @@ int main(int argc, char *argv[])
 
         drop_privileges(g->get<string>("user"), g->get<string>("group"));
 
+        // Install signal handling: SIGHUP logs; SIGTERM/SIGINT call smfi_stop()
+        SignalManager signal_manager;
+
         spdlog::info("gwmilter starting");
         gwmilter::milter m(g->get<string>("milter_socket"),
                            SMFIF_ADDHDRS | SMFIF_CHGHDRS | SMFIF_CHGBODY | SMFIF_ADDRCPT | SMFIF_ADDRCPT_PAR |
                                SMFIF_DELRCPT | SMFIF_QUARANTINE | SMFIF_CHGFROM | SMFIF_SETSYMLIST,
                            g->get<int>("milter_timeout"));
-
         m.run();
 
         spdlog::info("gwmilter shutting down");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 
         drop_privileges(g->get<string>("user"), g->get<string>("group"));
 
-        // Install signal handling: SIGHUP logs; SIGTERM/SIGINT call smfi_stop()
+        // Install signal handling
         SignalManager signal_manager;
 
         spdlog::info("gwmilter starting");

--- a/src/signal_manager.cpp
+++ b/src/signal_manager.cpp
@@ -1,0 +1,65 @@
+#include "signal_manager.hpp"
+#include <libmilter/mfapi.h>
+#include <spdlog/spdlog.h>
+
+namespace gwmilter {
+
+SignalManager::SignalManager()
+{
+    // Block signals in this thread so the dedicated thread can receive them via sigwait()
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGHUP);
+    sigaddset(&set, SIGTERM);
+    sigaddset(&set, SIGINT);
+
+    if (pthread_sigmask(SIG_BLOCK, &set, &old_set_) != 0)
+        throw std::runtime_error("SignalManager: Failed to block signals");
+
+    signal_thread_ = std::thread([this, set]() { signalLoop(set); });
+    spdlog::info("Signals installed: SIGHUP logs; SIGTERM/SIGINT stop libmilter");
+}
+
+SignalManager::~SignalManager()
+{
+    running_ = false;
+    if (signal_thread_.joinable()) {
+        // Wake sigwait() so the thread can exit; no-op when !running_
+        pthread_kill(signal_thread_.native_handle(), SIGINT);
+        signal_thread_.join();
+    }
+    // Restore previous signal mask for this thread
+    pthread_sigmask(SIG_SETMASK, &old_set_, nullptr);
+}
+
+void SignalManager::signalLoop(sigset_t set)
+{
+    int sig = 0;
+    for (;;) {
+        int rc = sigwait(&set, &sig);
+        if (!running_)
+            break; // ignore events during teardown
+        if (rc != 0) {
+            spdlog::error("SignalManager: sigwait failed: {}", rc);
+            break;
+        }
+
+        switch (sig) {
+        case SIGHUP:
+            spdlog::info("Received SIGHUP (reload requested)");
+            break;
+        case SIGTERM:
+            spdlog::info("Received SIGTERM (shutdown requested); stopping milter");
+            smfi_stop();
+            return; // exit thread
+        case SIGINT:
+            spdlog::info("Received SIGINT (shutdown requested); stopping milter");
+            smfi_stop();
+            return; // exit thread
+        default:
+            break;
+        }
+    }
+}
+
+} // namespace gwmilter

--- a/src/signal_manager.cpp
+++ b/src/signal_manager.cpp
@@ -6,7 +6,7 @@ namespace gwmilter {
 
 SignalManager::SignalManager()
 {
-    // Block signals in this thread so the dedicated thread can receive them via sigwait()
+    // Block signals in the current thread so the dedicated thread can receive them via sigwait()
     sigset_t set;
     sigemptyset(&set);
     sigaddset(&set, SIGHUP);
@@ -17,7 +17,7 @@ SignalManager::SignalManager()
         throw std::runtime_error("SignalManager: Failed to block signals");
 
     signal_thread_ = std::thread([this, set]() { signalLoop(set); });
-    spdlog::info("Signals installed: SIGHUP logs; SIGTERM/SIGINT stop libmilter");
+    spdlog::info("Signals installed: SIGHUP, SIGINT, SIGTERM");
 }
 
 SignalManager::~SignalManager()
@@ -46,7 +46,7 @@ void SignalManager::signalLoop(sigset_t set)
 
         switch (sig) {
         case SIGHUP:
-            spdlog::info("Received SIGHUP (reload requested)");
+            spdlog::info("Received SIGHUP (reload requested) - not implemented");
             break;
         case SIGTERM:
             spdlog::info("Received SIGTERM (shutdown requested); stopping milter");

--- a/src/signal_manager.hpp
+++ b/src/signal_manager.hpp
@@ -7,7 +7,7 @@
 namespace gwmilter {
 
 // Installs a dedicated sigwait() thread to handle POSIX signals.
-// - SIGHUP: log only for now
+// - SIGHUP: TODO: reload configuration
 // - SIGTERM/SIGINT: call libmilter's smfi_stop() and exit the thread
 class SignalManager {
 public:

--- a/src/signal_manager.hpp
+++ b/src/signal_manager.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <atomic>
+#include <csignal>
+#include <thread>
+
+namespace gwmilter {
+
+// Installs a dedicated sigwait() thread to handle POSIX signals.
+// - SIGHUP: log only for now
+// - SIGTERM/SIGINT: call libmilter's smfi_stop() and exit the thread
+class SignalManager {
+public:
+    SignalManager();
+    ~SignalManager();
+
+private:
+    void signalLoop(sigset_t set);
+
+    std::atomic<bool> running_{true};
+    std::thread signal_thread_;
+    sigset_t old_set_{}; // previous thread signal mask
+};
+
+} // namespace gwmilter


### PR DESCRIPTION
This PR introduces **SignalManager**, a `sigwait()` based handler for POSIX signals. It installs a dedicated thread, handles `SIGINT`/`SIGTERM` by calling `libmilter`'s `smfi_stop()`, and sets up `SIGHUP` for future configuration reloads.

This is a step toward supporting runtime config reloading.