### PR TITLE
Add unit tests for handlers and utils; unify test target

### DIFF
--- a/.github/workflows/Dockerfile.unit-tests
+++ b/.github/workflows/Dockerfile.unit-tests
@@ -79,13 +79,15 @@ FROM alpine:${ALPINE_VERSION} AS test-runner
 RUN apk add --no-cache \
     'glib~2.84' \
     'libstdc++~14.2' \
+    'boost1.84~1.84' \
     'fmt~11.2' \
     'spdlog~1.15' \
     'gtest~1.16' \
     'cmake~3.31' \
     'gmime~3.2' \
     'gpgme~1.24' \
-    'libharu~2.4'
+    'libharu~2.4' \
+    'icu-libs~76'
 
 # Copy built libraries from builder stage
 COPY --from=builder /usr/local/lib/libegpgcrypt.so* /usr/local/lib/

--- a/.github/workflows/Dockerfile.unit-tests
+++ b/.github/workflows/Dockerfile.unit-tests
@@ -82,7 +82,10 @@ RUN apk add --no-cache \
     'fmt~11.2' \
     'spdlog~1.15' \
     'gtest~1.16' \
-    'cmake~3.31'
+    'cmake~3.31' \
+    'gmime~3.2' \
+    'gpgme~1.24' \
+    'libharu~2.4'
 
 # Copy built libraries from builder stage
 COPY --from=builder /usr/local/lib/libegpgcrypt.so* /usr/local/lib/

--- a/.github/workflows/Dockerfile.unit-tests
+++ b/.github/workflows/Dockerfile.unit-tests
@@ -62,8 +62,6 @@ COPY CMakeLists.txt /app/
 COPY src/ /app/src/
 
 # Build unit tests
-# Note: gwmilter_tests is a unified test suite containing all unit tests
-# (utils, handlers, cfg2 module). Previously split into gwmilter_tests and cfg2_tests.
 RUN cmake \
     -DBUILD_TESTING=ON \
     -DEGPGCRYPT_PATH=/usr/local \

--- a/.github/workflows/Dockerfile.unit-tests
+++ b/.github/workflows/Dockerfile.unit-tests
@@ -62,16 +62,17 @@ COPY CMakeLists.txt /app/
 COPY src/ /app/src/
 
 # Build unit tests
+# Note: gwmilter_tests is a unified test suite containing all unit tests
+# (utils, handlers, cfg2 module). Previously split into gwmilter_tests and cfg2_tests.
 RUN cmake \
     -DBUILD_TESTING=ON \
-    -DENABLE_CFG2=ON \
     -DEGPGCRYPT_PATH=/usr/local \
     -DEPDFCRYPT_PATH=/usr/local \
     -DWERROR=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -B build \
     -S . && \
-    cmake --build build --target cfg2_tests -- -j$(nproc)
+    cmake --build build --target gwmilter_tests -- -j$(nproc)
 
 # Stage 2: Test runner (minimal runtime environment)
 FROM alpine:${ALPINE_VERSION} AS test-runner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,8 @@ if(BUILD_TESTING)
         PkgConfig::GMIME
     )
 
+    target_compile_definitions(gwmilter_tests PRIVATE UNIT_TESTING)
+
     set_target_properties(gwmilter_tests PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,8 +211,8 @@ else()
         "  2. Allow git fetch with -DFETCH_EXTERNAL_LIBS=ON")
 endif()
 
-# Toggle cfg2 module and utilities (demo/tests) on demand; default OFF while migrating
-option(ENABLE_CFG2 "Build cfg2 module and utilities (demo/tests)" OFF)
+# Toggle cfg2 demo executable (cfg2 module itself is always built as part of gwmilter)
+option(ENABLE_CFG2_DEMO "Build cfg2_demo standalone executable" OFF)
 
 # Set include directories for gwmilter target
 target_include_directories(gwmilter PRIVATE
@@ -265,12 +265,97 @@ option(BUILD_TESTING "Enable building tests via CTest/GTest" OFF)
 include(CTest)
 if(BUILD_TESTING)
     enable_testing()
+
+    find_package(GTest REQUIRED)
+    include(GoogleTest)
+
+    # ============================================
+    # gwmilter_tests: Unified test suite for all gwmilter components
+    # ============================================
+    add_executable(gwmilter_tests
+        # Utils tests
+        src/utils/string_tests.cpp
+        src/utils/uid_generator_tests.cpp
+        # Handlers tests
+        src/handlers/noop_body_handler_tests.cpp
+        src/handlers/body_handler_base_tests.cpp
+        src/handlers/pgp_body_handler_tests.cpp
+        src/handlers/smime_body_handler_tests.cpp
+        src/handlers/pdf_body_handler_tests.cpp
+        # cfg2 tests
+        src/cfg2/deserializer_tests.cpp
+        src/cfg2/dynamic_section_tests.cpp
+        src/cfg2/config_tests.cpp
+        src/cfg2/config_node_tests.cpp
+        src/cfg2/ini_reader_tests.cpp
+        src/cfg2/multiple_same_type_test.cpp
+        # Source files needed for tests
+        src/utils/string.cpp
+        src/utils/uid_generator.cpp
+        src/handlers/body_handler.cpp
+        src/handlers/noop_body_handler.cpp
+        src/handlers/pgp_body_handler.cpp
+        src/handlers/smime_body_handler.cpp
+        src/handlers/pdf_body_handler.cpp
+        src/cfg2/section_registry.cpp
+        src/cfg2/config.cpp
+        src/cfg2/ini_reader.cpp
+        src/cfg2/config_manager.cpp
+    )
+
+    target_include_directories(gwmilter_tests PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
+        ${EGPGCRYPT_INCLUDE_DIR}
+        ${EPDFCRYPT_INCLUDE_DIR}
+        ${GLIB_INCLUDE_DIRS}
+        ${GMIME_INCLUDE_DIRS}
+        ${simpleini_SOURCE_DIR}
+    )
+
+    target_link_libraries(gwmilter_tests PRIVATE
+        GTest::gtest_main
+        spdlog::spdlog
+        fmt::fmt
+        ${EGPGCRYPT_LIBRARY}
+        ${EPDFCRYPT_LIBRARY}
+        PkgConfig::GLIB
+        PkgConfig::GMIME
+    )
+
+    set_target_properties(gwmilter_tests PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+    )
+
+    # Add external library dependencies if built externally
+    if(USE_EGPGCRYPT_EXTERNAL)
+        add_dependencies(gwmilter_tests egpgcrypt_external)
+        set_target_properties(gwmilter_tests PROPERTIES
+            BUILD_RPATH "${EGPGCRYPT_INSTALL_DIR}/lib")
+    endif()
+    if(USE_EPDFCRYPT_EXTERNAL)
+        add_dependencies(gwmilter_tests epdfcrypt_external)
+        get_target_property(existing_rpath gwmilter_tests BUILD_RPATH)
+        if(existing_rpath)
+            set_target_properties(gwmilter_tests PROPERTIES
+                BUILD_RPATH "${existing_rpath}:${EPDFCRYPT_INSTALL_DIR}/lib")
+        else()
+            set_target_properties(gwmilter_tests PROPERTIES
+                BUILD_RPATH "${EPDFCRYPT_INSTALL_DIR}/lib")
+        endif()
+    endif()
+
+    # Register GoogleTest-based tests individually with CTest
+    gtest_discover_tests(gwmilter_tests
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DISCOVERY_TIMEOUT 60
+    )
 endif()
 
-if(ENABLE_CFG2)
+if(ENABLE_CFG2_DEMO)
     find_package(Threads REQUIRED)
 
-    # Add cfg2 demo executable with new modular structure
+    # Add cfg2 demo executable - standalone demonstration of cfg2 functionality
     add_executable(cfg2_demo
         src/cfg2/demo.cpp
         src/cfg2/section_registry.cpp
@@ -282,8 +367,8 @@ if(ENABLE_CFG2)
 
     target_include_directories(cfg2_demo PRIVATE
         ${PROJECT_SOURCE_DIR}/src
-    ${simpleini_SOURCE_DIR}
-)
+        ${simpleini_SOURCE_DIR}
+    )
 
     target_link_libraries(cfg2_demo
         PRIVATE
@@ -296,45 +381,4 @@ if(ENABLE_CFG2)
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
     )
-
-    if(BUILD_TESTING)
-        find_package(GTest REQUIRED)
-        include(GoogleTest)
-
-        # Add cfg2 tests executable with Google Test
-        add_executable(cfg2_tests
-            src/cfg2/deserializer_tests.cpp
-            src/cfg2/dynamic_section_tests.cpp
-            src/cfg2/config_tests.cpp
-            src/cfg2/config_node_tests.cpp
-            src/cfg2/ini_reader_tests.cpp
-            src/cfg2/multiple_same_type_test.cpp
-            src/cfg2/section_registry.cpp
-            src/cfg2/config.cpp
-            src/cfg2/ini_reader.cpp
-            src/cfg2/config_manager.cpp
-            src/utils/string.cpp
-        )
-
-        target_include_directories(cfg2_tests PRIVATE
-            ${PROJECT_SOURCE_DIR}/src
-            ${simpleini_SOURCE_DIR}
-        )
-
-        target_link_libraries(cfg2_tests PRIVATE
-            GTest::gtest_main
-            spdlog::spdlog
-        )
-
-        set_target_properties(cfg2_tests PROPERTIES
-            CXX_STANDARD 17
-            CXX_STANDARD_REQUIRED ON
-        )
-
-        # Register GoogleTest-based tests individually with CTest
-        gtest_discover_tests(cfg2_tests
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            DISCOVERY_TIMEOUT 60
-        )
-    endif()
 endif()

--- a/src/handlers/body_handler.hpp
+++ b/src/handlers/body_handler.hpp
@@ -8,6 +8,10 @@
 #include <set>
 #include <string>
 
+#ifdef UNIT_TESTING
+#include <gtest/gtest_prod.h>
+#endif
+
 namespace cfg2 {
 struct PdfEncryptionSection;
 }
@@ -33,6 +37,15 @@ public:
     const std::set<std::string> &failed_recipients() { return expired_keys_; }
 
 protected:
+#ifdef UNIT_TESTING
+    FRIEND_TEST(BodyHandlerBaseTest, GenerateBoundaryReturnsCorrectLength);
+    FRIEND_TEST(BodyHandlerBaseTest, GenerateBoundaryContainsOnlyValidChars);
+    FRIEND_TEST(ExtractContentHeadersTest, ExtractContentHeadersFindsContentType);
+    FRIEND_TEST(ExtractContentHeadersTest, ExtractContentHeadersCaseInsensitive);
+    FRIEND_TEST(ExtractContentHeadersTest, ExtractContentHeadersMarksAsModified);
+    FRIEND_TEST(ExtractContentHeadersTest, ExtractContentHeadersHandlesNoContentHeaders);
+#endif
+
     static std::string generate_boundary(std::size_t length = 70);
 
     // returns value of Content-Type and fills the param with all

--- a/src/handlers/body_handler_base_tests.cpp
+++ b/src/handlers/body_handler_base_tests.cpp
@@ -1,0 +1,175 @@
+#include "body_handler.hpp"
+#include <cctype>
+#include <gtest/gtest.h>
+
+using namespace gwmilter;
+
+// Helper class to expose protected methods for testing
+class TestableBodyHandler : public body_handler_base {
+public:
+    headers_type get_headers() override { return headers_; }
+    void encrypt(const recipients_type &, std::string &) override { }
+    bool has_public_key(const std::string &) const override { return true; }
+    bool import_public_key(const std::string &) override { return true; }
+
+    // Expose protected methods
+    static std::string public_generate_boundary(std::size_t length = 70) { return generate_boundary(length); }
+
+    std::string public_extract_content_headers(headers_type &content_headers)
+    {
+        return extract_content_headers(content_headers);
+    }
+};
+
+// Test body_handler_base protected methods via helper subclass
+class BodyHandlerBaseTest : public ::testing::Test {
+protected:
+    TestableBodyHandler handler;
+
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+// ============================================
+// generate_boundary tests
+// ============================================
+
+TEST_F(BodyHandlerBaseTest, GenerateBoundaryReturnsCorrectLength)
+{
+    // Test default length (70)
+    std::string boundary = TestableBodyHandler::public_generate_boundary();
+    EXPECT_EQ(boundary.length(), 70);
+
+    // Test custom lengths
+    std::string short_boundary = TestableBodyHandler::public_generate_boundary(10);
+    EXPECT_EQ(short_boundary.length(), 10);
+
+    std::string long_boundary = TestableBodyHandler::public_generate_boundary(100);
+    EXPECT_EQ(long_boundary.length(), 100);
+}
+
+TEST_F(BodyHandlerBaseTest, GenerateBoundaryContainsOnlyValidChars)
+{
+    std::string boundary = TestableBodyHandler::public_generate_boundary(100);
+
+    // RFC 2046 allows alphanumeric characters for boundaries
+    for (char c: boundary)
+        EXPECT_TRUE(std::isalnum(static_cast<unsigned char>(c))) << "Boundary contains invalid character: " << c;
+}
+
+// ============================================
+// add_header tests
+// ============================================
+
+TEST_F(BodyHandlerBaseTest, AddHeaderStoresHeaderCorrectly)
+{
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom", "value");
+
+    headers_type headers = handler.get_headers();
+
+    EXPECT_EQ(headers.size(), 2);
+    EXPECT_EQ(headers[0].name, "Content-Type");
+    EXPECT_EQ(headers[0].value, "text/plain");
+    EXPECT_EQ(headers[1].name, "X-Custom");
+    EXPECT_EQ(headers[1].value, "value");
+}
+
+TEST_F(BodyHandlerBaseTest, AddHeaderTracksIndexPerName)
+{
+    // Add multiple headers with the same name
+    handler.add_header("Received", "from server1");
+    handler.add_header("Received", "from server2");
+    handler.add_header("X-Other", "value");
+    handler.add_header("Received", "from server3");
+
+    headers_type headers = handler.get_headers();
+
+    // Check that indices increment per header name
+    EXPECT_EQ(headers[0].name, "Received");
+    EXPECT_EQ(headers[0].index, 1);
+
+    EXPECT_EQ(headers[1].name, "Received");
+    EXPECT_EQ(headers[1].index, 2);
+
+    EXPECT_EQ(headers[2].name, "X-Other");
+    EXPECT_EQ(headers[2].index, 1);
+
+    EXPECT_EQ(headers[3].name, "Received");
+    EXPECT_EQ(headers[3].index, 3);
+}
+
+// ============================================
+// extract_content_headers tests
+// ============================================
+
+class ExtractContentHeadersTest : public ::testing::Test {
+protected:
+    TestableBodyHandler handler;
+
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+TEST_F(ExtractContentHeadersTest, ExtractContentHeadersFindsContentType)
+{
+    handler.add_header("Content-Type", "text/html; charset=utf-8");
+    handler.add_header("X-Custom", "value");
+    handler.add_header("Content-Transfer-Encoding", "quoted-printable");
+
+    headers_type content_headers;
+    std::string content_type = handler.public_extract_content_headers(content_headers);
+
+    // Should return Content-Type value in lowercase
+    EXPECT_EQ(content_type, "text/html; charset=utf-8");
+
+    // Should extract both Content-* headers
+    EXPECT_EQ(content_headers.size(), 2);
+    EXPECT_EQ(content_headers[0].name, "Content-Type");
+    EXPECT_EQ(content_headers[1].name, "Content-Transfer-Encoding");
+}
+
+TEST_F(ExtractContentHeadersTest, ExtractContentHeadersCaseInsensitive)
+{
+    handler.add_header("content-type", "text/plain");
+    handler.add_header("CONTENT-ENCODING", "gzip");
+    handler.add_header("Content-Disposition", "attachment");
+
+    headers_type content_headers;
+    std::string content_type = handler.public_extract_content_headers(content_headers);
+
+    EXPECT_EQ(content_type, "text/plain");
+    EXPECT_EQ(content_headers.size(), 3);
+}
+
+TEST_F(ExtractContentHeadersTest, ExtractContentHeadersMarksAsModified)
+{
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom", "value");
+
+    headers_type content_headers;
+    handler.public_extract_content_headers(content_headers);
+
+    // Get all headers and check modification status
+    headers_type all_headers = handler.get_headers();
+
+    // Content-Type should be marked as modified
+    EXPECT_TRUE(all_headers[0].modified);
+    EXPECT_TRUE(all_headers[0].value.empty());
+
+    // X-Custom should not be modified
+    EXPECT_FALSE(all_headers[1].modified);
+    EXPECT_EQ(all_headers[1].value, "value");
+}
+
+TEST_F(ExtractContentHeadersTest, ExtractContentHeadersHandlesNoContentHeaders)
+{
+    handler.add_header("X-Custom", "value");
+    handler.add_header("Received", "from somewhere");
+
+    headers_type content_headers;
+    std::string content_type = handler.public_extract_content_headers(content_headers);
+
+    EXPECT_TRUE(content_type.empty());
+    EXPECT_TRUE(content_headers.empty());
+}

--- a/src/handlers/body_handler_base_tests.cpp
+++ b/src/handlers/body_handler_base_tests.cpp
@@ -35,6 +35,10 @@ TEST_F(BodyHandlerBaseTest, GenerateBoundaryReturnsCorrectLength)
 
     std::string long_boundary = body_handler_base::generate_boundary(100);
     EXPECT_EQ(long_boundary.length(), 100);
+
+    // Edge case: zero length
+    std::string empty_boundary = body_handler_base::generate_boundary(0);
+    EXPECT_EQ(empty_boundary.length(), 0);
 }
 
 TEST_F(BodyHandlerBaseTest, GenerateBoundaryContainsOnlyValidChars)

--- a/src/handlers/noop_body_handler_tests.cpp
+++ b/src/handlers/noop_body_handler_tests.cpp
@@ -1,0 +1,83 @@
+#include "body_handler.hpp"
+#include <gtest/gtest.h>
+
+using namespace gwmilter;
+
+class NoopBodyHandlerTest : public ::testing::Test {
+protected:
+    noop_body_handler handler;
+
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+TEST_F(NoopBodyHandlerTest, WriteAccumulatesData)
+{
+    handler.write("First chunk");
+    handler.write(" Second chunk");
+    handler.write(" Third chunk");
+
+    std::string output;
+    handler.encrypt({}, output);
+
+    EXPECT_EQ(output, "First chunk Second chunk Third chunk");
+}
+
+TEST_F(NoopBodyHandlerTest, EncryptSwapsDataToOutput)
+{
+    handler.write("Test data");
+
+    std::string output;
+    handler.encrypt({}, output);
+
+    EXPECT_EQ(output, "Test data");
+
+    // After encrypt, internal data should be empty (swapped)
+    std::string second_output;
+    handler.encrypt({}, second_output);
+    EXPECT_EQ(second_output, "");
+}
+
+TEST_F(NoopBodyHandlerTest, GetHeadersReturnsStoredHeaders)
+{
+    // noop_body_handler inherits from body_handler_base
+    // which stores headers added via add_header
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom-Header", "test-value");
+
+    headers_type headers = handler.get_headers();
+
+    EXPECT_EQ(headers.size(), 2);
+    EXPECT_EQ(headers[0].name, "Content-Type");
+    EXPECT_EQ(headers[0].value, "text/plain");
+    EXPECT_EQ(headers[1].name, "X-Custom-Header");
+    EXPECT_EQ(headers[1].value, "test-value");
+}
+
+TEST_F(NoopBodyHandlerTest, HasPublicKeyAlwaysReturnsTrue)
+{
+    // noop_body_handler always returns true (pass-through, no PKI)
+    EXPECT_TRUE(handler.has_public_key("anyone@example.com"));
+    EXPECT_TRUE(handler.has_public_key(""));
+    EXPECT_TRUE(handler.has_public_key("invalid-email"));
+}
+
+TEST_F(NoopBodyHandlerTest, ImportPublicKeyAlwaysReturnsTrue)
+{
+    // noop_body_handler always returns true (pass-through, no PKI)
+    EXPECT_TRUE(handler.import_public_key("anyone@example.com"));
+    EXPECT_TRUE(handler.import_public_key(""));
+    EXPECT_TRUE(handler.import_public_key("invalid-email"));
+}
+
+TEST_F(NoopBodyHandlerTest, EncryptIgnoresRecipients)
+{
+    handler.write("Message content");
+
+    std::set<std::string> recipients{"alice@example.com", "bob@example.com"};
+    std::string output;
+    handler.encrypt(recipients, output);
+
+    // Recipients are ignored; output is just the accumulated data
+    EXPECT_EQ(output, "Message content");
+}

--- a/src/handlers/noop_body_handler_tests.cpp
+++ b/src/handlers/noop_body_handler_tests.cpp
@@ -6,22 +6,7 @@ using namespace gwmilter;
 class NoopBodyHandlerTest : public ::testing::Test {
 protected:
     noop_body_handler handler;
-
-    void SetUp() override { }
-    void TearDown() override { }
 };
-
-TEST_F(NoopBodyHandlerTest, WriteAccumulatesData)
-{
-    handler.write("First chunk");
-    handler.write(" Second chunk");
-    handler.write(" Third chunk");
-
-    std::string output;
-    handler.encrypt({}, output);
-
-    EXPECT_EQ(output, "First chunk Second chunk Third chunk");
-}
 
 TEST_F(NoopBodyHandlerTest, EncryptSwapsDataToOutput)
 {
@@ -36,48 +21,4 @@ TEST_F(NoopBodyHandlerTest, EncryptSwapsDataToOutput)
     std::string second_output;
     handler.encrypt({}, second_output);
     EXPECT_EQ(second_output, "");
-}
-
-TEST_F(NoopBodyHandlerTest, GetHeadersReturnsStoredHeaders)
-{
-    // noop_body_handler inherits from body_handler_base
-    // which stores headers added via add_header
-    handler.add_header("Content-Type", "text/plain");
-    handler.add_header("X-Custom-Header", "test-value");
-
-    headers_type headers = handler.get_headers();
-
-    EXPECT_EQ(headers.size(), 2);
-    EXPECT_EQ(headers[0].name, "Content-Type");
-    EXPECT_EQ(headers[0].value, "text/plain");
-    EXPECT_EQ(headers[1].name, "X-Custom-Header");
-    EXPECT_EQ(headers[1].value, "test-value");
-}
-
-TEST_F(NoopBodyHandlerTest, HasPublicKeyAlwaysReturnsTrue)
-{
-    // noop_body_handler always returns true (pass-through, no PKI)
-    EXPECT_TRUE(handler.has_public_key("anyone@example.com"));
-    EXPECT_TRUE(handler.has_public_key(""));
-    EXPECT_TRUE(handler.has_public_key("invalid-email"));
-}
-
-TEST_F(NoopBodyHandlerTest, ImportPublicKeyAlwaysReturnsTrue)
-{
-    // noop_body_handler always returns true (pass-through, no PKI)
-    EXPECT_TRUE(handler.import_public_key("anyone@example.com"));
-    EXPECT_TRUE(handler.import_public_key(""));
-    EXPECT_TRUE(handler.import_public_key("invalid-email"));
-}
-
-TEST_F(NoopBodyHandlerTest, EncryptIgnoresRecipients)
-{
-    handler.write("Message content");
-
-    std::set<std::string> recipients{"alice@example.com", "bob@example.com"};
-    std::string output;
-    handler.encrypt(recipients, output);
-
-    // Recipients are ignored; output is just the accumulated data
-    EXPECT_EQ(output, "Message content");
 }

--- a/src/handlers/pdf_body_handler_tests.cpp
+++ b/src/handlers/pdf_body_handler_tests.cpp
@@ -1,85 +1,42 @@
 #include "body_handler.hpp"
 #include "cfg2/config.hpp"
 #include <algorithm>
-#include <filesystem>
-#include <fstream>
 #include <gtest/gtest.h>
 
 using namespace gwmilter;
 
 class PdfBodyHandlerTest : public ::testing::Test {
 protected:
-    std::filesystem::path test_dir;
     cfg2::PdfEncryptionSection default_settings;
 
     void SetUp() override
     {
-        // Create temporary directory for test files
-        test_dir = std::filesystem::temp_directory_path() / "gwmilter_pdf_tests";
-        std::filesystem::create_directories(test_dir);
-
-        // Set up default settings
         default_settings.encryption_protocol = cfg2::EncryptionProtocol::Pdf;
         default_settings.match = {".*@example\\.com"};
         default_settings.pdf_attachment = "test.pdf";
         default_settings.pdf_font_size = 12.0f;
         default_settings.pdf_margin = 10.0f;
     }
-
-    void TearDown() override
-    {
-        // Clean up test directory
-        if (std::filesystem::exists(test_dir))
-            std::filesystem::remove_all(test_dir);
-    }
-
-    void create_test_file(const std::string &filename, const std::string &content)
-    {
-        std::ofstream file(test_dir / filename);
-        file << content;
-        file.close();
-    }
 };
-
-// ============================================
-// get_headers tests
-// ============================================
 
 TEST_F(PdfBodyHandlerTest, GetHeadersReturnsMultipartMixed)
 {
     pdf_body_handler handler(default_settings);
     headers_type headers = handler.get_headers();
 
-    // Should have at least the Content-Type header
     ASSERT_FALSE(headers.empty());
 
-    // Find Content-Type header
     auto it =
         std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
     ASSERT_NE(it, headers.end());
 
-    // Check it contains multipart/mixed
     EXPECT_NE(it->value.find("multipart/mixed"), std::string::npos);
-}
-
-TEST_F(PdfBodyHandlerTest, GetHeadersIncludesBoundary)
-{
-    pdf_body_handler handler(default_settings);
-    headers_type headers = handler.get_headers();
-
-    auto it =
-        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
-    ASSERT_NE(it, headers.end());
-
-    // Should have a boundary parameter
-    EXPECT_NE(it->value.find("boundary="), std::string::npos);
 }
 
 TEST_F(PdfBodyHandlerTest, GetHeadersUpdatesExistingContentType)
 {
     pdf_body_handler handler(default_settings);
 
-    // Add an existing Content-Type header
     handler.add_header("Content-Type", "text/plain");
     handler.add_header("X-Custom", "value");
 
@@ -88,73 +45,8 @@ TEST_F(PdfBodyHandlerTest, GetHeadersUpdatesExistingContentType)
     // Should still have 2 headers (Content-Type updated, not duplicated)
     EXPECT_EQ(headers.size(), 2);
 
-    // Content-Type should be updated to multipart/mixed
     auto it =
         std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
     ASSERT_NE(it, headers.end());
     EXPECT_NE(it->value.find("multipart/mixed"), std::string::npos);
-}
-
-TEST_F(PdfBodyHandlerTest, GetHeadersCreatesContentTypeIfMissing)
-{
-    pdf_body_handler handler(default_settings);
-
-    // Don't add any headers
-    headers_type headers = handler.get_headers();
-
-    // Should create Content-Type header
-    EXPECT_EQ(headers.size(), 1);
-    EXPECT_EQ(headers[0].name, "Content-Type");
-    EXPECT_NE(headers[0].value.find("multipart/mixed"), std::string::npos);
-}
-
-// Note: read_file() is a private static method used internally by pdf_body_handler.
-// Since the class is marked final and the method is private, we cannot test it directly.
-// Its behavior is tested indirectly through encrypt() tests, which are beyond Phase 1 scope
-// and will be added in Phase 2 with mocking support.
-
-// ============================================
-// has_public_key / import_public_key tests
-// ============================================
-
-TEST_F(PdfBodyHandlerTest, HasPublicKeyAlwaysReturnsTrue)
-{
-    pdf_body_handler handler(default_settings);
-
-    // PDF encryption doesn't use PKI; always returns true
-    EXPECT_TRUE(handler.has_public_key("anyone@example.com"));
-    EXPECT_TRUE(handler.has_public_key(""));
-    EXPECT_TRUE(handler.has_public_key("invalid-email"));
-}
-
-TEST_F(PdfBodyHandlerTest, ImportPublicKeyAlwaysReturnsTrue)
-{
-    pdf_body_handler handler(default_settings);
-
-    // PDF encryption doesn't use PKI; always returns true
-    EXPECT_TRUE(handler.import_public_key("anyone@example.com"));
-    EXPECT_TRUE(handler.import_public_key(""));
-    EXPECT_TRUE(handler.import_public_key("invalid-email"));
-}
-
-// ============================================
-// Settings storage tests
-// ============================================
-
-TEST_F(PdfBodyHandlerTest, HandlerStoresSettings)
-{
-    cfg2::PdfEncryptionSection settings;
-    settings.encryption_protocol = cfg2::EncryptionProtocol::Pdf;
-    settings.match = {".*@test\\.com"};
-    settings.pdf_attachment = "custom.pdf";
-    settings.pdf_font_path = "/custom/font/path";
-    settings.pdf_font_size = 14.5f;
-    settings.pdf_margin = 20.0f;
-    settings.pdf_password = "secret";
-    settings.pdf_main_page_if_missing = "/path/to/main.txt";
-    settings.email_body_replacement = "/path/to/replacement.txt";
-
-    // Just verify handler can be constructed with custom settings
-    // (actual usage is tested in encrypt(), which is complex and beyond Phase 1 scope)
-    EXPECT_NO_THROW({ pdf_body_handler handler(settings); });
 }

--- a/src/handlers/pdf_body_handler_tests.cpp
+++ b/src/handlers/pdf_body_handler_tests.cpp
@@ -1,0 +1,160 @@
+#include "body_handler.hpp"
+#include "cfg2/config.hpp"
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+using namespace gwmilter;
+
+class PdfBodyHandlerTest : public ::testing::Test {
+protected:
+    std::filesystem::path test_dir;
+    cfg2::PdfEncryptionSection default_settings;
+
+    void SetUp() override
+    {
+        // Create temporary directory for test files
+        test_dir = std::filesystem::temp_directory_path() / "gwmilter_pdf_tests";
+        std::filesystem::create_directories(test_dir);
+
+        // Set up default settings
+        default_settings.encryption_protocol = cfg2::EncryptionProtocol::Pdf;
+        default_settings.match = {".*@example\\.com"};
+        default_settings.pdf_attachment = "test.pdf";
+        default_settings.pdf_font_size = 12.0f;
+        default_settings.pdf_margin = 10.0f;
+    }
+
+    void TearDown() override
+    {
+        // Clean up test directory
+        if (std::filesystem::exists(test_dir))
+            std::filesystem::remove_all(test_dir);
+    }
+
+    void create_test_file(const std::string &filename, const std::string &content)
+    {
+        std::ofstream file(test_dir / filename);
+        file << content;
+        file.close();
+    }
+};
+
+// ============================================
+// get_headers tests
+// ============================================
+
+TEST_F(PdfBodyHandlerTest, GetHeadersReturnsMultipartMixed)
+{
+    pdf_body_handler handler(default_settings);
+    headers_type headers = handler.get_headers();
+
+    // Should have at least the Content-Type header
+    ASSERT_FALSE(headers.empty());
+
+    // Find Content-Type header
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Check it contains multipart/mixed
+    EXPECT_NE(it->value.find("multipart/mixed"), std::string::npos);
+}
+
+TEST_F(PdfBodyHandlerTest, GetHeadersIncludesBoundary)
+{
+    pdf_body_handler handler(default_settings);
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Should have a boundary parameter
+    EXPECT_NE(it->value.find("boundary="), std::string::npos);
+}
+
+TEST_F(PdfBodyHandlerTest, GetHeadersUpdatesExistingContentType)
+{
+    pdf_body_handler handler(default_settings);
+
+    // Add an existing Content-Type header
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom", "value");
+
+    headers_type headers = handler.get_headers();
+
+    // Should still have 2 headers (Content-Type updated, not duplicated)
+    EXPECT_EQ(headers.size(), 2);
+
+    // Content-Type should be updated to multipart/mixed
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_NE(it->value.find("multipart/mixed"), std::string::npos);
+}
+
+TEST_F(PdfBodyHandlerTest, GetHeadersCreatesContentTypeIfMissing)
+{
+    pdf_body_handler handler(default_settings);
+
+    // Don't add any headers
+    headers_type headers = handler.get_headers();
+
+    // Should create Content-Type header
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].name, "Content-Type");
+    EXPECT_NE(headers[0].value.find("multipart/mixed"), std::string::npos);
+}
+
+// Note: read_file() is a private static method used internally by pdf_body_handler.
+// Since the class is marked final and the method is private, we cannot test it directly.
+// Its behavior is tested indirectly through encrypt() tests, which are beyond Phase 1 scope
+// and will be added in Phase 2 with mocking support.
+
+// ============================================
+// has_public_key / import_public_key tests
+// ============================================
+
+TEST_F(PdfBodyHandlerTest, HasPublicKeyAlwaysReturnsTrue)
+{
+    pdf_body_handler handler(default_settings);
+
+    // PDF encryption doesn't use PKI; always returns true
+    EXPECT_TRUE(handler.has_public_key("anyone@example.com"));
+    EXPECT_TRUE(handler.has_public_key(""));
+    EXPECT_TRUE(handler.has_public_key("invalid-email"));
+}
+
+TEST_F(PdfBodyHandlerTest, ImportPublicKeyAlwaysReturnsTrue)
+{
+    pdf_body_handler handler(default_settings);
+
+    // PDF encryption doesn't use PKI; always returns true
+    EXPECT_TRUE(handler.import_public_key("anyone@example.com"));
+    EXPECT_TRUE(handler.import_public_key(""));
+    EXPECT_TRUE(handler.import_public_key("invalid-email"));
+}
+
+// ============================================
+// Settings storage tests
+// ============================================
+
+TEST_F(PdfBodyHandlerTest, HandlerStoresSettings)
+{
+    cfg2::PdfEncryptionSection settings;
+    settings.encryption_protocol = cfg2::EncryptionProtocol::Pdf;
+    settings.match = {".*@test\\.com"};
+    settings.pdf_attachment = "custom.pdf";
+    settings.pdf_font_path = "/custom/font/path";
+    settings.pdf_font_size = 14.5f;
+    settings.pdf_margin = 20.0f;
+    settings.pdf_password = "secret";
+    settings.pdf_main_page_if_missing = "/path/to/main.txt";
+    settings.email_body_replacement = "/path/to/replacement.txt";
+
+    // Just verify handler can be constructed with custom settings
+    // (actual usage is tested in encrypt(), which is complex and beyond Phase 1 scope)
+    EXPECT_NO_THROW({ pdf_body_handler handler(settings); });
+}

--- a/src/handlers/pgp_body_handler_tests.cpp
+++ b/src/handlers/pgp_body_handler_tests.cpp
@@ -1,0 +1,116 @@
+#include "body_handler.hpp"
+#include <algorithm>
+#include <gtest/gtest.h>
+
+using namespace gwmilter;
+
+// Test pgp_body_handler's get_headers() method
+// (encrypt() tests require mocking crypto and will come in Phase 2)
+class PgpBodyHandlerHeadersTest : public ::testing::Test {
+protected:
+    pgp_body_handler handler;
+
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersReturnsMultipartEncrypted)
+{
+    headers_type headers = handler.get_headers();
+
+    // Should have at least the Content-Type header
+    ASSERT_FALSE(headers.empty());
+
+    // Find Content-Type header
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Check it contains multipart/encrypted
+    EXPECT_NE(it->value.find("multipart/encrypted"), std::string::npos);
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersIncludesPgpProtocol)
+{
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // RFC 3156 requires protocol="application/pgp-encrypted"
+    EXPECT_NE(it->value.find("application/pgp-encrypted"), std::string::npos);
+    EXPECT_NE(it->value.find("protocol="), std::string::npos);
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersIncludesBoundary)
+{
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Should have a boundary parameter
+    EXPECT_NE(it->value.find("boundary="), std::string::npos);
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersUpdatesExistingContentType)
+{
+    // Add an existing Content-Type header
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom", "value");
+
+    headers_type headers = handler.get_headers();
+
+    // Should still have 2 headers (Content-Type updated, not duplicated)
+    EXPECT_EQ(headers.size(), 2);
+
+    // Content-Type should be updated to multipart/encrypted
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_NE(it->value.find("multipart/encrypted"), std::string::npos);
+
+    // X-Custom should remain unchanged
+    auto custom_it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "X-Custom"; });
+    ASSERT_NE(custom_it, headers.end());
+    EXPECT_EQ(custom_it->value, "value");
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersCreatesContentTypeIfMissing)
+{
+    // Don't add any headers
+    headers_type headers = handler.get_headers();
+
+    // Should create Content-Type header
+    EXPECT_EQ(headers.size(), 1);
+    EXPECT_EQ(headers[0].name, "Content-Type");
+    EXPECT_NE(headers[0].value.find("multipart/encrypted"), std::string::npos);
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersMarksContentTypeAsModified)
+{
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // modified flag should be set to true (index=1, modified=true per code)
+    EXPECT_TRUE(it->modified);
+}
+
+TEST_F(PgpBodyHandlerHeadersTest, GetHeadersMultipleCallsReturnSameHeaders)
+{
+    headers_type headers1 = handler.get_headers();
+    headers_type headers2 = handler.get_headers();
+
+    // Should return the same headers on multiple calls
+    EXPECT_EQ(headers1.size(), headers2.size());
+
+    // Content-Type should be the same
+    EXPECT_EQ(headers1[0].name, headers2[0].name);
+    EXPECT_EQ(headers1[0].value, headers2[0].value);
+}

--- a/src/handlers/pgp_body_handler_tests.cpp
+++ b/src/handlers/pgp_body_handler_tests.cpp
@@ -10,8 +10,6 @@ class PgpBodyHandlerHeadersTest : public ::testing::Test {
 protected:
     pgp_body_handler handler;
 
-    void SetUp() override { }
-    void TearDown() override { }
 };
 
 TEST_F(PgpBodyHandlerHeadersTest, GetHeadersReturnsMultipartEncrypted)
@@ -41,18 +39,6 @@ TEST_F(PgpBodyHandlerHeadersTest, GetHeadersIncludesPgpProtocol)
     // RFC 3156 requires protocol="application/pgp-encrypted"
     EXPECT_NE(it->value.find("application/pgp-encrypted"), std::string::npos);
     EXPECT_NE(it->value.find("protocol="), std::string::npos);
-}
-
-TEST_F(PgpBodyHandlerHeadersTest, GetHeadersIncludesBoundary)
-{
-    headers_type headers = handler.get_headers();
-
-    auto it =
-        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
-    ASSERT_NE(it, headers.end());
-
-    // Should have a boundary parameter
-    EXPECT_NE(it->value.find("boundary="), std::string::npos);
 }
 
 TEST_F(PgpBodyHandlerHeadersTest, GetHeadersUpdatesExistingContentType)
@@ -90,27 +76,3 @@ TEST_F(PgpBodyHandlerHeadersTest, GetHeadersCreatesContentTypeIfMissing)
     EXPECT_NE(headers[0].value.find("multipart/encrypted"), std::string::npos);
 }
 
-TEST_F(PgpBodyHandlerHeadersTest, GetHeadersMarksContentTypeAsModified)
-{
-    headers_type headers = handler.get_headers();
-
-    auto it =
-        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
-    ASSERT_NE(it, headers.end());
-
-    // modified flag should be set to true (index=1, modified=true per code)
-    EXPECT_TRUE(it->modified);
-}
-
-TEST_F(PgpBodyHandlerHeadersTest, GetHeadersMultipleCallsReturnSameHeaders)
-{
-    headers_type headers1 = handler.get_headers();
-    headers_type headers2 = handler.get_headers();
-
-    // Should return the same headers on multiple calls
-    EXPECT_EQ(headers1.size(), headers2.size());
-
-    // Content-Type should be the same
-    EXPECT_EQ(headers1[0].name, headers2[0].name);
-    EXPECT_EQ(headers1[0].value, headers2[0].value);
-}

--- a/src/handlers/smime_body_handler_tests.cpp
+++ b/src/handlers/smime_body_handler_tests.cpp
@@ -10,8 +10,6 @@ class SmimeBodyHandlerHeadersTest : public ::testing::Test {
 protected:
     smime_body_handler handler;
 
-    void SetUp() override { }
-    void TearDown() override { }
 };
 
 TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersReturnsPkcs7MimeType)
@@ -42,18 +40,6 @@ TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersIncludesSmimeType)
     EXPECT_NE(it->value.find("smime-type=enveloped-data"), std::string::npos);
 }
 
-TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersIncludesFilename)
-{
-    headers_type headers = handler.get_headers();
-
-    auto it =
-        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
-    ASSERT_NE(it, headers.end());
-
-    // Should have name="smime.p7m"
-    EXPECT_NE(it->value.find("name=\"smime.p7m\""), std::string::npos);
-}
-
 TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsTransferEncoding)
 {
     headers_type headers = handler.get_headers();
@@ -75,17 +61,6 @@ TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsContentDisposition)
     ASSERT_NE(it, headers.end());
     EXPECT_NE(it->value.find("attachment"), std::string::npos);
     EXPECT_NE(it->value.find("smime.p7m"), std::string::npos);
-}
-
-TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsContentDescription)
-{
-    headers_type headers = handler.get_headers();
-
-    // Should have Content-Description header
-    auto it = std::find_if(headers.begin(), headers.end(),
-                           [](const header_item &h) { return h.name == "Content-Description"; });
-    ASSERT_NE(it, headers.end());
-    EXPECT_NE(it->value.find("S/MIME Encrypted Message"), std::string::npos);
 }
 
 TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersUpdatesExistingContentType)
@@ -137,18 +112,3 @@ TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersOnlyAddsExtraHeadersOnce)
     EXPECT_EQ(description_count, 1);
 }
 
-TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersMarksHeadersAsModified)
-{
-    headers_type headers = handler.get_headers();
-
-    // All headers created by get_headers() should be marked as modified
-    auto content_type =
-        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
-    ASSERT_NE(content_type, headers.end());
-    EXPECT_TRUE(content_type->modified);
-
-    auto transfer_encoding = std::find_if(headers.begin(), headers.end(),
-                                          [](const header_item &h) { return h.name == "Content-Transfer-Encoding"; });
-    ASSERT_NE(transfer_encoding, headers.end());
-    EXPECT_TRUE(transfer_encoding->modified);
-}

--- a/src/handlers/smime_body_handler_tests.cpp
+++ b/src/handlers/smime_body_handler_tests.cpp
@@ -1,0 +1,154 @@
+#include "body_handler.hpp"
+#include <algorithm>
+#include <gtest/gtest.h>
+
+using namespace gwmilter;
+
+// Test smime_body_handler's get_headers() method
+// (encrypt() tests require mocking crypto and will come in Phase 2)
+class SmimeBodyHandlerHeadersTest : public ::testing::Test {
+protected:
+    smime_body_handler handler;
+
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersReturnsPkcs7MimeType)
+{
+    headers_type headers = handler.get_headers();
+
+    // Should have at least the Content-Type header
+    ASSERT_FALSE(headers.empty());
+
+    // Find Content-Type header
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Check it contains application/pkcs7-mime
+    EXPECT_NE(it->value.find("application/pkcs7-mime"), std::string::npos);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersIncludesSmimeType)
+{
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Should have smime-type=enveloped-data
+    EXPECT_NE(it->value.find("smime-type=enveloped-data"), std::string::npos);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersIncludesFilename)
+{
+    headers_type headers = handler.get_headers();
+
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+
+    // Should have name="smime.p7m"
+    EXPECT_NE(it->value.find("name=\"smime.p7m\""), std::string::npos);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsTransferEncoding)
+{
+    headers_type headers = handler.get_headers();
+
+    // Should have Content-Transfer-Encoding header
+    auto it = std::find_if(headers.begin(), headers.end(),
+                           [](const header_item &h) { return h.name == "Content-Transfer-Encoding"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_EQ(it->value, "base64");
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsContentDisposition)
+{
+    headers_type headers = handler.get_headers();
+
+    // Should have Content-Disposition header
+    auto it = std::find_if(headers.begin(), headers.end(),
+                           [](const header_item &h) { return h.name == "Content-Disposition"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_NE(it->value.find("attachment"), std::string::npos);
+    EXPECT_NE(it->value.find("smime.p7m"), std::string::npos);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersAddsContentDescription)
+{
+    headers_type headers = handler.get_headers();
+
+    // Should have Content-Description header
+    auto it = std::find_if(headers.begin(), headers.end(),
+                           [](const header_item &h) { return h.name == "Content-Description"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_NE(it->value.find("S/MIME Encrypted Message"), std::string::npos);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersUpdatesExistingContentType)
+{
+    // Add an existing Content-Type header
+    handler.add_header("Content-Type", "text/plain");
+    handler.add_header("X-Custom", "value");
+
+    headers_type headers = handler.get_headers();
+
+    // Content-Type should be updated to application/pkcs7-mime
+    auto it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(it, headers.end());
+    EXPECT_NE(it->value.find("application/pkcs7-mime"), std::string::npos);
+
+    // X-Custom should remain unchanged
+    auto custom_it =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "X-Custom"; });
+    ASSERT_NE(custom_it, headers.end());
+    EXPECT_EQ(custom_it->value, "value");
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersOnlyAddsExtraHeadersOnce)
+{
+    // Call get_headers() multiple times
+    headers_type headers1 = handler.get_headers();
+    size_t count1 = headers1.size();
+
+    headers_type headers2 = handler.get_headers();
+    size_t count2 = headers2.size();
+
+    // Should not duplicate the extra headers
+    EXPECT_EQ(count1, count2);
+
+    // Count Content-Transfer-Encoding headers (should be exactly 1)
+    int transfer_encoding_count = std::count_if(
+        headers2.begin(), headers2.end(), [](const header_item &h) { return h.name == "Content-Transfer-Encoding"; });
+    EXPECT_EQ(transfer_encoding_count, 1);
+
+    // Count Content-Disposition headers (should be exactly 1)
+    int disposition_count = std::count_if(headers2.begin(), headers2.end(),
+                                          [](const header_item &h) { return h.name == "Content-Disposition"; });
+    EXPECT_EQ(disposition_count, 1);
+
+    // Count Content-Description headers (should be exactly 1)
+    int description_count = std::count_if(headers2.begin(), headers2.end(),
+                                          [](const header_item &h) { return h.name == "Content-Description"; });
+    EXPECT_EQ(description_count, 1);
+}
+
+TEST_F(SmimeBodyHandlerHeadersTest, GetHeadersMarksHeadersAsModified)
+{
+    headers_type headers = handler.get_headers();
+
+    // All headers created by get_headers() should be marked as modified
+    auto content_type =
+        std::find_if(headers.begin(), headers.end(), [](const header_item &h) { return h.name == "Content-Type"; });
+    ASSERT_NE(content_type, headers.end());
+    EXPECT_TRUE(content_type->modified);
+
+    auto transfer_encoding = std::find_if(headers.begin(), headers.end(),
+                                          [](const header_item &h) { return h.name == "Content-Transfer-Encoding"; });
+    ASSERT_NE(transfer_encoding, headers.end());
+    EXPECT_TRUE(transfer_encoding->modified);
+}

--- a/src/utils/string_tests.cpp
+++ b/src/utils/string_tests.cpp
@@ -3,21 +3,18 @@
 
 using namespace gwmilter::utils::string;
 
-class StringUtilsTest : public ::testing::Test {
-};
-
 // ============================================
 // to_lower tests
 // ============================================
 
-TEST_F(StringUtilsTest, ToLowerConvertsUppercase)
+TEST(StringUtilsTest, ToLowerConvertsUppercase)
 {
     EXPECT_EQ(to_lower("HELLO"), "hello");
     EXPECT_EQ(to_lower("WORLD"), "world");
     EXPECT_EQ(to_lower("ABC123XYZ"), "abc123xyz");
 }
 
-TEST_F(StringUtilsTest, ToLowerPreservesNonAlpha)
+TEST(StringUtilsTest, ToLowerPreservesNonAlpha)
 {
     EXPECT_EQ(to_lower("Test-123!@#"), "test-123!@#");
     EXPECT_EQ(to_lower("user@DOMAIN.COM"), "user@domain.com");
@@ -27,20 +24,20 @@ TEST_F(StringUtilsTest, ToLowerPreservesNonAlpha)
 // iequals tests
 // ============================================
 
-TEST_F(StringUtilsTest, IequalsMatchesDifferentCase)
+TEST(StringUtilsTest, IequalsMatchesDifferentCase)
 {
     EXPECT_TRUE(iequals("Hello", "hello"));
     EXPECT_TRUE(iequals("WORLD", "world"));
     EXPECT_TRUE(iequals("Content-Type", "content-type"));
 }
 
-TEST_F(StringUtilsTest, IequalsReturnsFalseForDifferentStrings)
+TEST(StringUtilsTest, IequalsReturnsFalseForDifferentStrings)
 {
     EXPECT_FALSE(iequals("hello", "world"));
     EXPECT_FALSE(iequals("test", "testing"));
 }
 
-TEST_F(StringUtilsTest, IequalsHandlesEmptyStrings)
+TEST(StringUtilsTest, IequalsHandlesEmptyStrings)
 {
     EXPECT_TRUE(iequals("", ""));
     EXPECT_FALSE(iequals("", "nonempty"));
@@ -51,13 +48,13 @@ TEST_F(StringUtilsTest, IequalsHandlesEmptyStrings)
 // set_to_string tests
 // ============================================
 
-TEST_F(StringUtilsTest, SetToStringSingleElement)
+TEST(StringUtilsTest, SetToStringSingleElement)
 {
     std::set<std::string> single_set{"alice@example.com"};
     EXPECT_EQ(set_to_string(single_set), "alice@example.com");
 }
 
-TEST_F(StringUtilsTest, SetToStringMultipleElements)
+TEST(StringUtilsTest, SetToStringMultipleElements)
 {
     std::set<std::string> multi_set{"alice@example.com", "bob@example.com", "charlie@example.com"};
     // Sets are ordered, so we can predict the output

--- a/src/utils/string_tests.cpp
+++ b/src/utils/string_tests.cpp
@@ -4,9 +4,6 @@
 using namespace gwmilter::utils::string;
 
 class StringUtilsTest : public ::testing::Test {
-protected:
-    void SetUp() override { }
-    void TearDown() override { }
 };
 
 // ============================================
@@ -20,17 +17,6 @@ TEST_F(StringUtilsTest, ToLowerConvertsUppercase)
     EXPECT_EQ(to_lower("ABC123XYZ"), "abc123xyz");
 }
 
-TEST_F(StringUtilsTest, ToLowerHandlesEmptyString)
-{
-    EXPECT_EQ(to_lower(""), "");
-}
-
-TEST_F(StringUtilsTest, ToLowerHandlesMixedCase)
-{
-    EXPECT_EQ(to_lower("HeLLo WoRLd"), "hello world");
-    EXPECT_EQ(to_lower("CamelCase"), "camelcase");
-}
-
 TEST_F(StringUtilsTest, ToLowerPreservesNonAlpha)
 {
     EXPECT_EQ(to_lower("Test-123!@#"), "test-123!@#");
@@ -40,12 +26,6 @@ TEST_F(StringUtilsTest, ToLowerPreservesNonAlpha)
 // ============================================
 // iequals tests
 // ============================================
-
-TEST_F(StringUtilsTest, IequalsMatchesSameCase)
-{
-    EXPECT_TRUE(iequals("hello", "hello"));
-    EXPECT_TRUE(iequals("WORLD", "WORLD"));
-}
 
 TEST_F(StringUtilsTest, IequalsMatchesDifferentCase)
 {
@@ -67,21 +47,9 @@ TEST_F(StringUtilsTest, IequalsHandlesEmptyStrings)
     EXPECT_FALSE(iequals("nonempty", ""));
 }
 
-TEST_F(StringUtilsTest, IequalsReturnsFalseForDifferentLengths)
-{
-    EXPECT_FALSE(iequals("short", "longer"));
-    EXPECT_FALSE(iequals("abc", "ab"));
-}
-
 // ============================================
 // set_to_string tests
 // ============================================
-
-TEST_F(StringUtilsTest, SetToStringFormatsEmptySet)
-{
-    std::set<std::string> empty_set;
-    EXPECT_EQ(set_to_string(empty_set), "");
-}
 
 TEST_F(StringUtilsTest, SetToStringSingleElement)
 {
@@ -94,19 +62,4 @@ TEST_F(StringUtilsTest, SetToStringMultipleElements)
     std::set<std::string> multi_set{"alice@example.com", "bob@example.com", "charlie@example.com"};
     // Sets are ordered, so we can predict the output
     EXPECT_EQ(set_to_string(multi_set), "alice@example.com, bob@example.com, charlie@example.com");
-}
-
-// ============================================
-// str_err tests
-// ============================================
-
-TEST_F(StringUtilsTest, StrErrReturnsValidMessage)
-{
-    // ENOENT should return a non-empty message
-    std::string msg = str_err(ENOENT);
-    EXPECT_FALSE(msg.empty());
-    // The message should contain some indication of "no such file"
-    std::string lower_msg = to_lower(msg);
-    EXPECT_TRUE(lower_msg.find("no such") != std::string::npos || lower_msg.find("not found") != std::string::npos ||
-                lower_msg.find("file") != std::string::npos);
 }

--- a/src/utils/string_tests.cpp
+++ b/src/utils/string_tests.cpp
@@ -1,0 +1,112 @@
+#include "string.hpp"
+#include <gtest/gtest.h>
+
+using namespace gwmilter::utils::string;
+
+class StringUtilsTest : public ::testing::Test {
+protected:
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+// ============================================
+// to_lower tests
+// ============================================
+
+TEST_F(StringUtilsTest, ToLowerConvertsUppercase)
+{
+    EXPECT_EQ(to_lower("HELLO"), "hello");
+    EXPECT_EQ(to_lower("WORLD"), "world");
+    EXPECT_EQ(to_lower("ABC123XYZ"), "abc123xyz");
+}
+
+TEST_F(StringUtilsTest, ToLowerHandlesEmptyString)
+{
+    EXPECT_EQ(to_lower(""), "");
+}
+
+TEST_F(StringUtilsTest, ToLowerHandlesMixedCase)
+{
+    EXPECT_EQ(to_lower("HeLLo WoRLd"), "hello world");
+    EXPECT_EQ(to_lower("CamelCase"), "camelcase");
+}
+
+TEST_F(StringUtilsTest, ToLowerPreservesNonAlpha)
+{
+    EXPECT_EQ(to_lower("Test-123!@#"), "test-123!@#");
+    EXPECT_EQ(to_lower("user@DOMAIN.COM"), "user@domain.com");
+}
+
+// ============================================
+// iequals tests
+// ============================================
+
+TEST_F(StringUtilsTest, IequalsMatchesSameCase)
+{
+    EXPECT_TRUE(iequals("hello", "hello"));
+    EXPECT_TRUE(iequals("WORLD", "WORLD"));
+}
+
+TEST_F(StringUtilsTest, IequalsMatchesDifferentCase)
+{
+    EXPECT_TRUE(iequals("Hello", "hello"));
+    EXPECT_TRUE(iequals("WORLD", "world"));
+    EXPECT_TRUE(iequals("Content-Type", "content-type"));
+}
+
+TEST_F(StringUtilsTest, IequalsReturnsFalseForDifferentStrings)
+{
+    EXPECT_FALSE(iequals("hello", "world"));
+    EXPECT_FALSE(iequals("test", "testing"));
+}
+
+TEST_F(StringUtilsTest, IequalsHandlesEmptyStrings)
+{
+    EXPECT_TRUE(iequals("", ""));
+    EXPECT_FALSE(iequals("", "nonempty"));
+    EXPECT_FALSE(iequals("nonempty", ""));
+}
+
+TEST_F(StringUtilsTest, IequalsReturnsFalseForDifferentLengths)
+{
+    EXPECT_FALSE(iequals("short", "longer"));
+    EXPECT_FALSE(iequals("abc", "ab"));
+}
+
+// ============================================
+// set_to_string tests
+// ============================================
+
+TEST_F(StringUtilsTest, SetToStringFormatsEmptySet)
+{
+    std::set<std::string> empty_set;
+    EXPECT_EQ(set_to_string(empty_set), "");
+}
+
+TEST_F(StringUtilsTest, SetToStringSingleElement)
+{
+    std::set<std::string> single_set{"alice@example.com"};
+    EXPECT_EQ(set_to_string(single_set), "alice@example.com");
+}
+
+TEST_F(StringUtilsTest, SetToStringMultipleElements)
+{
+    std::set<std::string> multi_set{"alice@example.com", "bob@example.com", "charlie@example.com"};
+    // Sets are ordered, so we can predict the output
+    EXPECT_EQ(set_to_string(multi_set), "alice@example.com, bob@example.com, charlie@example.com");
+}
+
+// ============================================
+// str_err tests
+// ============================================
+
+TEST_F(StringUtilsTest, StrErrReturnsValidMessage)
+{
+    // ENOENT should return a non-empty message
+    std::string msg = str_err(ENOENT);
+    EXPECT_FALSE(msg.empty());
+    // The message should contain some indication of "no such file"
+    std::string lower_msg = to_lower(msg);
+    EXPECT_TRUE(lower_msg.find("no such") != std::string::npos || lower_msg.find("not found") != std::string::npos ||
+                lower_msg.find("file") != std::string::npos);
+}

--- a/src/utils/uid_generator_tests.cpp
+++ b/src/utils/uid_generator_tests.cpp
@@ -6,9 +6,6 @@
 using namespace gwmilter;
 
 class UidGeneratorTest : public ::testing::Test {
-protected:
-    void SetUp() override { }
-    void TearDown() override { }
 };
 
 TEST_F(UidGeneratorTest, GenerateReturnsExpectedLength)

--- a/src/utils/uid_generator_tests.cpp
+++ b/src/utils/uid_generator_tests.cpp
@@ -35,10 +35,10 @@ TEST_F(UidGeneratorTest, GenerateReturnsUniqueValues)
     uid_generator gen;
     std::set<std::string> generated_uids;
 
-    // Generate 1000 UIDs and check they're unique
+    // Generate 100 UIDs and check they're unique
     // With 32-bit random values formatted as 8 hex digits,
     // the chance of collision in 1000 samples is extremely low
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 100; ++i) {
         std::string uid = gen.generate();
         EXPECT_TRUE(generated_uids.insert(uid).second) << "Duplicate UID generated: " << uid;
     }

--- a/src/utils/uid_generator_tests.cpp
+++ b/src/utils/uid_generator_tests.cpp
@@ -1,0 +1,48 @@
+#include "uid_generator.hpp"
+#include <cctype>
+#include <gtest/gtest.h>
+#include <set>
+
+using namespace gwmilter;
+
+class UidGeneratorTest : public ::testing::Test {
+protected:
+    void SetUp() override { }
+    void TearDown() override { }
+};
+
+TEST_F(UidGeneratorTest, GenerateReturnsExpectedLength)
+{
+    uid_generator gen;
+    std::string uid = gen.generate();
+
+    // Format is {:08X} which produces 8 hex characters
+    EXPECT_EQ(uid.length(), 8);
+}
+
+TEST_F(UidGeneratorTest, GenerateReturnsHexCharactersOnly)
+{
+    uid_generator gen;
+    std::string uid = gen.generate();
+
+    // Check all characters are valid hex (0-9, A-F)
+    for (char c: uid) {
+        EXPECT_TRUE(std::isxdigit(static_cast<unsigned char>(c)));
+        // fmt's {:X} format produces uppercase hex
+        EXPECT_TRUE((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'));
+    }
+}
+
+TEST_F(UidGeneratorTest, GenerateReturnsUniqueValues)
+{
+    uid_generator gen;
+    std::set<std::string> generated_uids;
+
+    // Generate 1000 UIDs and check they're unique
+    // With 32-bit random values formatted as 8 hex digits,
+    // the chance of collision in 1000 samples is extremely low
+    for (int i = 0; i < 1000; ++i) {
+        std::string uid = gen.generate();
+        EXPECT_TRUE(generated_uids.insert(uid).second) << "Duplicate UID generated: " << uid;
+    }
+}


### PR DESCRIPTION
## Summary

- Consolidate `cfg2_tests` into a single `gwmilter_tests` target that covers all components (cfg2, handlers, utils)
- Remove the `ENABLE_CFG2` gate for tests — `BUILD_TESTING` alone now controls the test build
- Rename `ENABLE_CFG2` to `ENABLE_CFG2_DEMO` since it only governs the demo executable
- Add 31 new tests across 7 files (handlers + utils), 122 total passing