### PR TITLE
Replace rand() with modern C++ <random> facilities

### DIFF
--- a/src/handlers/body_handler.cpp
+++ b/src/handlers/body_handler.cpp
@@ -1,6 +1,7 @@
 #include "body_handler.hpp"
 #include "logger/logger.hpp"
 #include "utils/string.hpp"
+#include <random>
 
 namespace gwmilter {
 
@@ -55,12 +56,15 @@ void body_handler_base::postprocess()
 
 std::string body_handler_base::generate_boundary(std::size_t length)
 {
-    static std::string allowed_chars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890");
+    static const std::string allowed_chars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890");
+    static thread_local std::mt19937_64 rng{std::random_device{}()};
+    std::uniform_int_distribution<std::size_t> dist(0, allowed_chars.size() - 1);
+
     std::string boundary;
     boundary.resize(length);
 
-    for (unsigned int i = 0; i < length; ++i)
-        boundary[i] = allowed_chars[rand() % allowed_chars.size()];
+    for (std::size_t i = 0; i < length; ++i)
+        boundary[i] = allowed_chars[dist(rng)];
 
     return boundary;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,9 +110,6 @@ int main(int argc, char *argv[])
     }
 
     try {
-        // seed random number generator
-        srand(time(nullptr));
-
         // Initialize cfg2 configuration system
         auto config_mgr = cfg2::ConfigManager(config_file);
         const auto config = config_mgr.getConfig();


### PR DESCRIPTION
Use a thread_local std::mt19937_64 seeded from std::random_device in
generate_boundary(), replacing the weak rand()/srand(time()) pattern.
This fixes thread safety, eliminates modulo bias via
std::uniform_int_distribution, and provides proper entropy seeding.

Remove the now-unused srand(time(nullptr)) call from main().

https://claude.ai/code/session_01UPcD99W1865m2gY9Pj7AA9