### PR TITLE
Fix CVE-2026-24486: Upgrade python-multipart to 0.0.22

### DIFF
--- a/integrations/key-server/requirements.txt
+++ b/integrations/key-server/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-python-multipart==0.0.20
+python-multipart==0.0.22
 python-gnupg==0.5.5


### PR DESCRIPTION
## Summary

- Upgrades `python-multipart` from `0.0.20` to `0.0.22` to fix a high-severity path traversal vulnerability (CVE-2026-24486)
- Resolves Dependabot security alert

## Details

The vulnerability allows arbitrary file write when using non-default configuration (`UPLOAD_DIR` + `UPLOAD_KEEP_FILENAME=True`). While the default configuration is not vulnerable, upgrading is recommended as a defense-in-depth measure.

**CVSS Score**: 8.6 (High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)