### PR TITLE
Fix CodeQL path injection alerts in key-server

### DIFF
--- a/integrations/key-server/app.py
+++ b/integrations/key-server/app.py
@@ -52,7 +52,13 @@ def get_key_by_email(email: str) -> str | None:
     Retrieve a PGP key for the given email address.
     """
     email = sanitize_email(email)
-    key_path = KEYS_DIR / f"{email}.pgp"
+    key_path = (KEYS_DIR / f"{email}.pgp").resolve()
+
+    # Defense in depth: ensure path is within KEYS_DIR
+    if not key_path.is_relative_to(KEYS_DIR.resolve()):
+        logger.warning(f"Path traversal attempt detected for email: {email}")
+        raise HTTPException(status_code=400, detail="Invalid email format")
+
     if not key_path.exists():
         return None
 


### PR DESCRIPTION
## Summary

- Adds explicit path containment check in `get_key_by_email()` to ensure the resolved file path remains within `KEYS_DIR`
- Resolves code scanning alerts [#1](https://github.com/drclau/gwmilter/security/code-scanning/1) and [#2](https://github.com/drclau/gwmilter/security/code-scanning/2) (`py/path-injection`)

## Details

This is a defense-in-depth fix. The existing `sanitize_email()` function already blocks path traversal characters via regex validation (`[A-Za-z0-9_.+\-@]+`), but static analysis tools can't trace through function calls to verify this.

The fix uses `Path.resolve()` to get the canonical absolute path, then `is_relative_to()` to verify the path remains within the allowed directory. This satisfies CodeQL and provides an additional safety layer against path traversal attacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)