### PR TITLE
Fix CodeQL path injection alerts with os.path.realpath sanitizer

### DIFF
--- a/integrations/key-server/app.py
+++ b/integrations/key-server/app.py
@@ -52,13 +52,17 @@ def get_key_by_email(email: str) -> str | None:
     Retrieve a PGP key for the given email address.
     """
     email = sanitize_email(email)
-    key_path = (KEYS_DIR / f"{email}.pgp").resolve()
+    key_path = KEYS_DIR / f"{email}.pgp"
 
-    # Defense in depth: ensure path is within KEYS_DIR
-    if not key_path.is_relative_to(KEYS_DIR.resolve()):
+    # Resolve to real path and verify containment — uses os.path pattern
+    # recognized by static analysis tools as a path traversal guard
+    real_path = os.path.realpath(key_path)
+    safe_prefix = os.path.realpath(KEYS_DIR) + os.sep
+    if not real_path.startswith(safe_prefix):
         logger.warning(f"Path traversal attempt detected for email: {email}")
         raise HTTPException(status_code=400, detail="Invalid email format")
 
+    key_path = Path(real_path)
     if not key_path.exists():
         return None
 


### PR DESCRIPTION
## Summary

- Replace `pathlib.resolve()` + `is_relative_to()` with `os.path.realpath()` + `str.startswith()` in `get_key_by_email()` — the canonical pattern CodeQL recognizes as a path traversal sanitizer
- Append `os.sep` to the safe prefix to prevent prefix confusion (e.g., `/app/keys/public-extra/` matching `/app/keys/public`)
- Runtime behavior is identical to the previous guard; this change satisfies static analysis

## Resolves

CodeQL alerts #6, #7, #8 (`py/path-injection`)

## Test plan

- [ ] CodeQL re-scan after merge should clear all three path injection alerts
- [ ] Integration tests confirm key lookup still works (`/pks/lookup`, `/keys/{email}`)
- [ ] Verify path traversal attempts are still blocked (e.g., email containing `../`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)