### PR TITLE
Add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout code
@@ -54,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: unit-tests
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` to restrict the default GITHUB_TOKEN scope
- Grant `contents: read` + `checks: write` to `unit-tests` (checkout + JUnit report annotations)
- Grant `contents: read` to `integration-tests` (checkout only)
- Follows the same least-privilege pattern already used in `claude-code-review.yml` and `claude.yml`

## Resolves

CodeQL alerts #4, #5 (`actions/missing-workflow-permissions`)

## Test plan

- [ ] CI workflow runs on this PR itself to confirm checkout, Docker build, and JUnit report all work with the new permissions
- [ ] CodeQL re-scan after merge should clear both workflow permission alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)