### PR TITLE
Fix CVE-2026-40347: Upgrade python-multipart to 0.0.26

### DIFF
--- a/integrations/key-server/requirements.txt
+++ b/integrations/key-server/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 python-gnupg==0.5.5


### PR DESCRIPTION
## Summary

- Upgrades `python-multipart` from `0.0.22` to `0.0.26` to fix a medium-severity denial of service vulnerability (CVE-2026-40347)
- Resolves [Dependabot security alert #7](https://github.com/drclau/gwmilter/security/dependabot/7)

## Details

The vulnerability allows an attacker to consume excessive CPU time during `multipart/form-data` request parsing by sending oversized crafted data in the preamble (leading CR/LF bytes before the first boundary) or epilogue (trailing data after the closing boundary). The parser previously scanned these regions inefficiently; `0.0.26` skips ahead to the next boundary candidate for leading CR/LF data and discards epilogue data immediately after the closing boundary.

Impact is degraded availability under crafted requests rather than full service denial. No API changes.

**Severity**: Medium
**GHSA**: GHSA-mj87-hwqh-73pj