### PR TITLE
Fix CVE-2026-25645: Upgrade requests to 2.33.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.4.2
 python-gnupg==0.5.5
-requests==2.32.5
+requests==2.33.0
 dataclasses-json==0.6.7
 typing-extensions==4.15.0


### PR DESCRIPTION
## Summary

- Upgrades `requests` from `2.32.5` to `2.33.0` to fix a medium-severity insecure temp file reuse vulnerability (CVE-2026-25645)
- Resolves [Dependabot security alert #5](https://github.com/drclau/gwmilter/security/dependabot/5)

## Details

`requests.utils.extract_zipped_paths()` previously extracted files to a predictable filename in the system temp directory and reused an existing target file without validation. A local attacker with write access to the temp directory could pre-create a malicious file to be loaded in place of the legitimate one. `2.33.0` extracts to a non-deterministic location.

**Standard HTTP usage of `requests` is not affected** — only direct callers of `extract_zipped_paths()` are impacted. The test suite in this repo does not call that utility, so the practical exposure here is nil; this upgrade is defense-in-depth and clears the alert.

Scope is limited to `tests/requirements.txt` (dev/test only); no production code changes.

**Severity**: Medium (CVSS 4.4)
**GHSA**: GHSA-gc5v-m9x4-r6x2