### PR TITLE
Fix CVE-2025-71176: Upgrade pytest to 9.0.3

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==8.4.2
+pytest==9.0.3
 python-gnupg==0.5.5
 requests==2.32.5
 dataclasses-json==0.6.7


### PR DESCRIPTION
## Summary

- Upgrades `pytest` from `8.4.2` to `9.0.3` to fix a medium-severity local privilege escalation / denial of service vulnerability (CVE-2025-71176)
- Resolves [Dependabot security alert #6](https://github.com/drclau/gwmilter/security/dependabot/6)

## Details

On UNIX, pytest through `9.0.2` used a predictable `/tmp/pytest-of-{user}` tmpdir path pattern. A local user with write access to the shared temp directory could pre-create or symlink that path, causing a denial of service or potentially escalating privileges of the user running pytest. `9.0.3` changes the tmpdir handling to prevent this.

Scope is limited to `tests/requirements.txt` (dev/test only); no production code changes.

### Note on the major version bump

This is a major version upgrade (`8.4` → `9.0`). Pytest major releases typically turn prior deprecation warnings into errors and may reshape some plugin/fixture APIs. No breakage is expected against the current test suite but the full suite should be run locally before merge.

**Severity**: Medium (CVSS 6.8)
**GHSA**: GHSA-6w46-j5rx-g56g